### PR TITLE
always show 2 digits after floating-point

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,7 +164,7 @@
             value = res.buy;
 
             tl.restart();
-            document.getElementById('value').innerText = value;
+            document.getElementById('value').innerText = value.toFixed(2);
 
             chartTicker++;
             if (chartTicker === 6) {


### PR DESCRIPTION
Отображение с 74.05 до 74 выглядит хреново, поскольку выравнивание мелькает. Обычно в таких случаях всегда отображают нули после зпт, т.е. 74.00